### PR TITLE
Restored the operator+ compatibility

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -472,6 +472,9 @@ namespace detail {
     public:
         template<typename T>
         auto operator|( T const &other ) const -> Parser;
+		
+		template<typename T>
+        auto operator+( T const &other ) const -> Parser;
     };
 
     // Common code and state for Args and Opts
@@ -724,13 +727,28 @@ namespace detail {
             m_exeName = exeName;
             return *this;
         }
+		
+		auto operator+=( ExeName const &exeName ) -> Parser & {
+            m_exeName = exeName;
+            return *this;
+        }
 
         auto operator|=( Arg const &arg ) -> Parser & {
             m_args.push_back(arg);
             return *this;
         }
+		
+		auto operator+=( Arg const &arg ) -> Parser & {
+            m_args.push_back(arg);
+            return *this;
+        }
 
         auto operator|=( Opt const &opt ) -> Parser & {
+            m_options.push_back(opt);
+            return *this;
+        }
+
+        auto operator+( Opt const &opt ) -> Parser & {
             m_options.push_back(opt);
             return *this;
         }
@@ -741,8 +759,19 @@ namespace detail {
             return *this;
         }
 
+        auto operator+=( Parser const &other ) -> Parser & {
+            m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
+            m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
+            return *this;
+        }
+
         template<typename T>
         auto operator|( T const &other ) const -> Parser {
+            return Parser( *this ) |= other;
+        }
+
+        template<typename T>
+        auto operator+( T const &other ) const -> Parser {
             return Parser( *this ) |= other;
         }
 

--- a/single_include/clara.hpp
+++ b/single_include/clara.hpp
@@ -803,6 +803,9 @@ namespace detail {
     public:
         template<typename T>
         auto operator|( T const &other ) const -> Parser;
+		
+        template<typename T>
+        auto operator+( T const &other ) const -> Parser;
     };
 
     // Common code and state for Args and Opts
@@ -1056,12 +1059,27 @@ namespace detail {
             return *this;
         }
 
+        auto operator+=( ExeName const &exeName ) -> Parser & {
+            m_exeName = exeName;
+            return *this;
+        }
+
         auto operator|=( Arg const &arg ) -> Parser & {
             m_args.push_back(arg);
             return *this;
         }
 
+        auto operator+=( Arg const &arg ) -> Parser & {
+            m_args.push_back(arg);
+            return *this;
+        }
+
         auto operator|=( Opt const &opt ) -> Parser & {
+            m_options.push_back(opt);
+            return *this;
+        }
+
+        auto operator+=( Opt const &opt ) -> Parser & {
             m_options.push_back(opt);
             return *this;
         }
@@ -1072,8 +1090,19 @@ namespace detail {
             return *this;
         }
 
+        auto operator+=( Parser const &other ) -> Parser & {
+            m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
+            m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
+            return *this;
+        }
+
         template<typename T>
         auto operator|( T const &other ) const -> Parser {
+            return Parser( *this ) |= other;
+        }
+
+        template<typename T>
+        auto operator+( T const &other ) const -> Parser {
             return Parser( *this ) |= other;
         }
 


### PR DESCRIPTION
An older version of Clara is referenced in the [vcpkg](https://github.com/Microsoft/vcpkg) manager with the `operator+`.
[philsquared](https://github.com/philsquared) has changed the API for this library without backward-compatibility, so I'm restoring it.