### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ if( !result ) {
 
 Note that exceptions are not used for error handling.
 
-You can combine parsers by composing with `+`, like this:
+You can combine parsers by composing with `|`, like this:
 
 ```c++
 int width = 0;


### PR DESCRIPTION
The usage example in the readme shows how multiple parsers are combined with the `|` operator. However, the readme explitly refers to this as the `+` operator, which is not correct.

I know there is a discussion about whether or not the `+` operator should be permitted in addition to `|`, but I think things should be consistent in the readme at least 😃.