### PR TITLE
ClaraTests: Work around GCC bug with StringMaker specialisation

### DIFF
--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -6,8 +6,9 @@
 
 using namespace clara;
 
+namespace Catch {
 template<>
-struct Catch::StringMaker<clara::detail::InternalParseResult> {
+struct StringMaker<clara::detail::InternalParseResult> {
     static std::string convert( clara::detail::InternalParseResult const& result ) {
         switch( result.type() ) {
             case clara::detail::ResultBase::Ok:
@@ -21,6 +22,7 @@ struct Catch::StringMaker<clara::detail::InternalParseResult> {
         }
     }
 };
+}
 
 // !TBD
 // for Catch:


### PR DESCRIPTION
Support for specialising using a qualified name was only added in C++11.
Unfortunately, GCC didn't catch up until GCC7. See
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480 .

Revert to the C++03 method for the time being to support older GCC
versions.

In particular, Debian 9 is still using GCC6 as its system compiler, so the tests don't compile there.