### PR TITLE
Remove an extra semicolon

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -39,7 +39,7 @@ namespace detail {
     template<typename ClassT, typename ReturnT, typename ArgT>
     struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
         static const bool isValid = true;
-        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;;
+        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
         using ReturnType = ReturnT;
     };
 

--- a/single_include/clara.hpp
+++ b/single_include/clara.hpp
@@ -370,7 +370,7 @@ namespace detail {
     template<typename ClassT, typename ReturnT, typename ArgT>
     struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
         static const bool isValid = true;
-        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;;
+        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
         using ReturnType = ReturnT;
     };
 


### PR DESCRIPTION
If you run with a million GCC warnings on (we do), this'll trip -Wextra-semi.

I think I rematerialized single_include correctly (I just ran stitch), but please let me know if that needs anything else to be done with it.