### PR TITLE
Add support for std::optional if macro '__cpp_if_constexpr' returns 1

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -322,6 +322,18 @@ namespace detail {
         return ParserResult::ok( ParseResultType::Matched );
     }
 
+#if  __cpp_if_constexpr // is a C++17 feature. If this is there, then std::optional<T> too
+                        // __has_include is not rliable: gcc with -std=c++11 returns true here
+#define CLARA_OPTIONAL_VALUES
+    template<typename T>
+    inline auto convertInto( std::string const &source, std::optional<T>& target_opt ) -> ParserResult {
+        T target;
+        auto result = convertInto(source,target);
+        if (result)
+            target_opt = target;
+        return result;
+    }
+#endif
     struct BoundRefBase {
         BoundRefBase() = default;
         BoundRefBase( BoundRefBase const & ) = delete;

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -3,7 +3,7 @@
 #include "catch.hpp"
 
 #include <iostream>
-
+#include <optional>
 using namespace clara;
 
 namespace Catch {
@@ -38,6 +38,29 @@ struct StringMaker<clara::detail::InternalParseResult> {
 // other dependencies/ hierarchical parsers
 // Exclusive() parser for choices
 
+#ifdef CLARA_OPTIONAL_VALUES
+TEST_CASE( "optional value is not set" ) {
+    std::optional<std::string> name;
+    auto p = Opt(name, "name")
+    ["-n"]["--name"]
+            ("the name to use");
+    REQUIRE( !name.has_value() );
+
+}
+
+TEST_CASE( "optional value is set" ) {
+    std::optional<std::string> name;
+    auto parser = Opt(name, "name")
+    ["-n"]["--name"]
+            ("the name to use");
+    auto result = parser.parse( Args{ "TestApp", "-n", "Bill", "-d:123.45", "-f", "test1", "test2" } );
+    REQUIRE( name.has_value() );
+    CHECK( result );
+    CHECK( result.value().type() == ParseResultType::Matched );
+    REQUIRE( name.value() == "Bill" );
+
+}
+#endif
 TEST_CASE( "single parsers" ) {
 
     std::string name;

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -1,9 +1,11 @@
+#ifdef CLARA_OPTIONAL_VALUES
+#include <optional>
+#endif
 #include "clara.hpp"
 
 #include "catch.hpp"
 
 #include <iostream>
-#include <optional>
 using namespace clara;
 
 namespace Catch {

--- a/third_party/catch.hpp
+++ b/third_party/catch.hpp
@@ -7408,13 +7408,18 @@ namespace Catch {
         m_info.message = builder.m_stream.str();
         getResultCapture().pushScopedMessage( m_info );
     }
-
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996) // std::uncaught_exception is deprecated in C++17
+#endif
     ScopedMessage::~ScopedMessage() {
         if ( !std::uncaught_exception() ){
             getResultCapture().popScopedMessage(m_info);
         }
     }
-
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 } // end namespace Catch
 // end catch_message.cpp
 // start catch_notimplemented_exception.cpp


### PR DESCRIPTION
I really like the idea to put command line options into optional values.
This way the parser is not responsible for setting default values.
And if one compiles with C++17 this PR would make it possible to deal with std::optional<T> variables