### PR TITLE
Fix compiler error: extra ‘;’ [-Werror=pedantic]"

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -422,7 +422,7 @@ namespace detail {
         return !result
            ? result
            : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( lambda, temp );
-    };
+    }
 
 
     template<typename L>


### PR DESCRIPTION
The current code won't compile for me with maximum warning levels, and warnings as errors

Command line used to trigger error was:
`/usr/bin/c++    -I.../Clara/include  -W -Werror -Wall -Wextra -pedantic -g   -std=gnu++11`

```
/usr/bin/c++ --version
c++ (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
...
```