### PR TITLE
Fix overloads of `Arg::parse()`

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -579,6 +579,8 @@ namespace detail {
     public:
         using ParserRefImpl::ParserRefImpl;
 
+        using ParserBase::parse;
+
         auto parse( std::string const &, TokenStream const &tokens ) const -> InternalParseResult override {
             auto validationResult = validate();
             if( !validationResult )

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -73,6 +73,18 @@ TEST_CASE( "single parsers" ) {
     }
 }
 
+TEST_CASE( "single arg" ) {
+    std::string name;
+    auto p = Arg(name, "one lonely arg");
+
+    REQUIRE( name == "" );
+
+    SECTION( "foo" ) {
+        p.parse( Args{ "TestApp", "foo" } );
+        REQUIRE( name == "foo" );
+    }
+}
+
 struct Config {
     int m_rngSeed;
     std::string m_name;


### PR DESCRIPTION
…to match `Opt::parse().` Add test case parsing single `Arg,` no `Opt.`

I tried creating "simple" parser using `Arg` instead of `Opt`, based on the tutorial:
```
	int jumpto = 0;
	auto jarg = Arg(jumpto, "jump to");
	jarg.parse(Args{"exename", "10"});
```
 This failed, because `Arg` is not `using ParserBase::parse` the way `Opt` does. So I added a test case, and the `using` statement required to resolve it.

```
/Users/austin/Code/clara/src/ClaraTests.cpp:83:43: error: too few arguments to function
      call, expected 2, have 1
        p.parse( Args{ "TestApp", "foo" } );
        ~~~~~~~                           ^
/Users/austin/Code/clara/include/clara.hpp:582:9: note: 'parse' declared here
        auto parse( std::string const &, TokenStream const &tokens ) const -> Int...
        ^
1 error generated.
```
