### PR TITLE
Accept const char*[] argv in Args constructor

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -58,7 +58,7 @@ namespace detail {
         std::vector<std::string> m_args;
 
     public:
-        Args( int argc, char *argv[] ) {
+        Args( int argc, const char *argv[] ) {
             m_exeName = argv[0];
             for( int i = 1; i < argc; ++i )
                 m_args.push_back( argv[i] );


### PR DESCRIPTION
This makes it easier to run tests using string literals.   

Currently this fails:

```cpp
const char *v[] = { "arg0", "arg1" };
Args(2, v);          #   error: invalid conversion from 'const char**' to 'char**' 
```

and this warns (fails if you fail on warnings):

```cpp
char *v[] = { "arg0", "arg1" };  # warning: ISO C++ forbids converting a string constant to 'char*' 
Args(2, v);         
```

And so the only workable solution is to use `const_cast`