### PR TITLE
Support arguments starting with a dash

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -157,6 +157,20 @@ namespace detail {
             }
             return *this;
         }
+
+        void fetchArgument() {
+            if( m_tokenBuffer.size() >= 2 ) {
+                m_tokenBuffer.erase( m_tokenBuffer.begin() );
+            } else {
+                if( it != itEnd )
+                    ++it;
+
+                m_tokenBuffer.resize( 0 );
+
+                if( it != itEnd )
+                    m_tokenBuffer.push_back( { TokenType::Argument, *it } );
+           }
+        }
     };
 
 
@@ -663,7 +677,7 @@ namespace detail {
                         if( result.value() == ParseResultType::ShortCircuitAll )
                             return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
                     } else {
-                        ++remainingTokens;
+                        remainingTokens.fetchArgument();
                         if( !remainingTokens )
                             return InternalParseResult::runtimeError( "Expected argument following " + token.token );
                         auto const &argToken = *remainingTokens;

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -349,6 +349,11 @@ TEST_CASE( "Opt value can start with a dash" ) {
       CHECK( result );
       REQUIRE( name == "-bar" );
     }
+    SECTION( "empty args" ) {
+      auto result = parser.parse( Args{ "TestApp", "-n", "" } );
+      CHECK( result );
+      REQUIRE( name == "" );
+    }
 }
 
 TEST_CASE( "different widths" ) {

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -339,9 +339,16 @@ TEST_CASE( "Opt value can start with a dash" ) {
                 ["-n"]["--name"]
                 ( "the name to use" );
 
-    auto result = parser.parse( Args{ "TestApp", "-n", "-foobar" } );
-    CHECK( result );
-    REQUIRE( name == "-foobar" );
+    SECTION( "args" ) {
+      auto result = parser.parse( Args{ "TestApp", "-n", "-foo" } );
+      CHECK( result );
+      REQUIRE( name == "-foo" );
+    }
+    SECTION( "arg separated by =" ) {
+      auto result = parser.parse( Args{ "TestApp", "-n=-bar" } );
+      CHECK( result );
+      REQUIRE( name == "-bar" );
+    }
 }
 
 TEST_CASE( "different widths" ) {

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -330,6 +330,20 @@ std::string toString( Opt const& opt ) {
     return oss.str();
 }
 
+TEST_CASE( "Opt value can start with a dash" ) {
+    std::string name;
+    bool showHelp = false;
+    auto parser
+            = Help( showHelp )
+            | Opt( name, "name" )
+                ["-n"]["--name"]
+                ( "the name to use" );
+
+    auto result = parser.parse( Args{ "TestApp", "-n", "-foobar" } );
+    CHECK( result );
+    REQUIRE( name == "-foobar" );
+}
+
 TEST_CASE( "different widths" ) {
 
     std::string s;


### PR DESCRIPTION
I don't know how good this fits into TokenStream concept but the idea is if we know an argument will follow then advance stream and accept whatever follows without trying to parse it. That might be an argument separated by ' :=' (previously parsed) or an empty string (I've seen this quite often) or arbitrary data.

This is how I fixed issue #50 for me.