### PR TITLE
Interpret a single dash or slash as positional argument

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -102,7 +102,7 @@ namespace detail {
 
             if( it != itEnd ) {
                 auto const &next = *it;
-                if( isOptPrefix( next[0] ) ) {
+                if( isOptPrefix( next[0] ) && next.size() > 1 ) {
                     auto delimiterPos = next.find_first_of( " :=" );
                     if( delimiterPos != std::string::npos ) {
                         m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );

--- a/single_include/clara.hpp
+++ b/single_include/clara.hpp
@@ -433,7 +433,7 @@ namespace detail {
 
             if( it != itEnd ) {
                 auto const &next = *it;
-                if( isOptPrefix( next[0] ) ) {
+                if( isOptPrefix( next[0] ) && next.size() > 1 ) {
                     auto delimiterPos = next.find_first_of( " :=" );
                     if( delimiterPos != std::string::npos ) {
                         m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );

--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -330,6 +330,31 @@ std::string toString( Opt const& opt ) {
     return oss.str();
 }
 
+TEST_CASE( "dash as positional argument" ) {
+    std::string name;
+    bool showHelp = false;
+    auto parser
+            = Help( showHelp )
+            | Arg( name, "input file" )
+                 ( "Input file" );
+
+    SECTION( "args" ) {
+        auto result = parser.parse( Args{ "cat", "filename" } );
+        CHECK( result );
+        REQUIRE( name == "filename" );
+    }
+    SECTION( "dash arg" ) {
+        auto result = parser.parse( Args{ "cat", "-" } );
+        CHECK( result );
+        REQUIRE( name == "-" );
+    }
+    SECTION( "slash arg" ) {
+        auto result = parser.parse( Args{ "cat", "/" } );
+        CHECK( result );
+        REQUIRE( name == "/" );
+    }
+}
+
 TEST_CASE( "different widths" ) {
 
     std::string s;


### PR DESCRIPTION
Interpret a single dash as a positional argument which is a common convention for STDIN on Unix.

Fixes issue #57