### PR TITLE
Clara: TextFlow: fixed issue with word wrapping

### DIFF
--- a/include/clara_textflow.hpp
+++ b/include/clara_textflow.hpp
@@ -121,10 +121,7 @@ namespace clara { namespace TextFlow {
             auto operator *() const -> std::string {
                 assert( m_stringIndex < m_column.m_strings.size() );
                 assert( m_pos <= m_end );
-                if( m_pos + m_column.m_width < m_end )
-                    return addIndentAndSuffix(line().substr(m_pos, m_len));
-                else
-                    return addIndentAndSuffix(line().substr(m_pos, m_end - m_pos));
+                return addIndentAndSuffix(line().substr(m_pos, m_len));
             }
 
             auto operator ++() -> iterator& {


### PR DESCRIPTION
The issue with word wrapping was that in case that m_pos + width was
greater or equal to m_end it fallbacked to m_end-m_pos branch which
caused that printed string was greater than configured width.

Also caused duplication of words as in next iteration m_len was
added to m_pos this was less then m_end.

Originally reported in https://github.com/catchorg/Catch2/issues/1400