### PR TITLE
Adds CMake library and install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
 cmake_minimum_required(VERSION 3.8.2)
-project(Clara)
+project(Clara VERSION 1.1.5)
 
-set(SOURCE_FILES src/main.cpp src/ClaraTests.cpp include/clara.hpp)
-include_directories( include third_party )
+include(GNUInstallDirs)
+
+add_library(Clara INTERFACE)
+add_library(Clara::Clara ALIAS Clara)
+target_include_directories(Clara
+  INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_compile_features(Clara
+  INTERFACE cxx_trailing_return_types)
+
+set(SOURCE_FILES src/main.cpp src/ClaraTests.cpp)
 add_executable(ClaraTests ${SOURCE_FILES})
+target_include_directories(ClaraTests PRIVATE third_party)
+target_link_libraries(ClaraTests PRIVATE Clara::Clara)
 
 if(USE_CPP14)
     set_property(TARGET ClaraTests PROPERTY CXX_STANDARD 14)
@@ -37,3 +49,24 @@ endif()
 
 include(CTest)
 add_test(NAME RunTests COMMAND $<TARGET_FILE:ClaraTests>)
+
+set(target_export_name "${PROJECT_NAME}Targets")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+
+# install headers
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/single_include/"
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# install project config
+install(TARGETS Clara EXPORT ${target_export_name})
+install(EXPORT ${target_export_name}
+  NAMESPACE Clara::
+  DESTINATION ${config_install_dir}
+  FILE "${PROJECT_NAME}Config.cmake")
+
+# install version config
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${version_config}
+  COMPATIBILITY SameMajorVersion)
+install(FILES ${version_config} DESTINATION ${config_install_dir})


### PR DESCRIPTION
This PR
* adds an interface library target `Clara`, aliased `Clara::Clara`
* corresponding `install` entries are also added

  ```
  clara-install-prefix/
  |-- include
  |   `-- clara.hpp
  `-- lib
      `-- cmake
          `-- Clara
              |-- ClaraConfig.cmake
              `-- ClaraConfigVersion.cmake
  ```
  so `find_package(Clara REQUIRED)` can properly import `Clara::Clara` from the installed package.

* include directories needed for `ClaraTest` targets are now set using `target_include_directories` instead of changing global settings

This implements the main part of #44 