### PR TITLE
Fixed some warnings + added new warnings for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set_property(TARGET ClaraTests PROPERTY CXX_EXTENSIONS OFF)
 
 
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
-    target_compile_options( ClaraTests PRIVATE -Wall -Wextra -pedantic -Werror )
+    target_compile_options( ClaraTests PRIVATE -Wall -Wextra -pedantic -Werror -Wsign-conversion -Wshadow)
 endif()
 if( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 	target_compile_options( ClaraTests PRIVATE /W4 /WX )

--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -141,7 +141,7 @@ namespace detail {
     public:
         explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
 
-        TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
+        TokenStream( Iterator it_, Iterator itEnd_ ) : it( it_ ), itEnd( itEnd_ ) {
             loadBuffer();
         }
 

--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -149,7 +149,7 @@ namespace detail {
             return !m_tokenBuffer.empty() || it != itEnd;
         }
 
-        auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
+        auto count() const -> size_t { return m_tokenBuffer.size() + static_cast<size_t>(itEnd - it); }
 
         auto operator*() const -> Token {
             assert( !m_tokenBuffer.empty() );

--- a/single_include/clara.hpp
+++ b/single_include/clara.hpp
@@ -489,7 +489,7 @@ namespace detail {
             return !m_tokenBuffer.empty() || it != itEnd;
         }
 
-        auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
+        auto count() const -> size_t { return m_tokenBuffer.size() + static_cast<size_t>(itEnd - it); }
 
         auto operator*() const -> Token {
             assert( !m_tokenBuffer.empty() );

--- a/single_include/clara.hpp
+++ b/single_include/clara.hpp
@@ -481,7 +481,7 @@ namespace detail {
     public:
         explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
 
-        TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
+        TokenStream( Iterator it_, Iterator itEnd_ ) : it( it_ ), itEnd( itEnd_ ) {
             loadBuffer();
         }
 


### PR DESCRIPTION
This is not really a major change, but it helps out for any project that tries to build without any warnings like I do.

Added `-Wshadow` and `-Wsign-conversion` warnings to the gcc + clang warnings for the test suite. GCC does not turn these on by default with `-Wall` or `-Wextra`, and I don't know if clang bundles them the added warnings in its `-Wall` or `-Wextra`.

Also fixed a few lines in the headers that raised these warnings, namely appending an underscore for the shadow warning and a static cast to the sign conversion warning. I went with the underscore on the arguments as I figured there was a good reason that the `TokenStream::it` and `TokenStream::itEnd` members didn't have an `m_` prefix.