### PR TITLE
Make it possible to bind lambdas when passed by l-value

### DIFF
--- a/src/ClaraTests.cpp
+++ b/src/ClaraTests.cpp
@@ -305,6 +305,23 @@ TEST_CASE( "cmdline" ) {
     }
 }
 
+TEST_CASE( "bound lambdas " ) {
+    int someValue = 0;
+
+    SECTION( "binding lambda by lvalue" ) {
+        auto optionLambda = [&someValue]( int value ){ someValue = value; };
+
+        auto parser = Opt( optionLambda, "value" )
+            ["-v"];
+
+        const auto result = parser.parse( Args{ "TestApp", "-v", "42" } );
+        CHECK( result );
+        CHECK( result.value().type() == ParseResultType::Matched );
+
+        CHECK( someValue == 42 );
+    }
+}
+
 TEST_CASE( "flag parser" ) {
 
     bool flag = false;


### PR DESCRIPTION
Currently, lambdas can only be bound to `Opt`s when passed by r-value. I think it would be nice if lambdas could also be passed by l-value, since it would allow me to separate the parser definition from the logic inside the lambdas. This PR accomplishes that with the help of some SFINAE.

Fixes #58 