### PR TITLE
use ::std for tolower

### DIFF
--- a/include/clara.hpp
+++ b/include/clara.hpp
@@ -29,6 +29,7 @@
 
 #include "clara_textflow.hpp"
 
+#include <cctype>
 #include <vector>
 #include <memory>
 #include <sstream>
@@ -324,7 +325,7 @@ namespace detail {
     }
     inline auto convertInto( std::string const &source, bool &target ) -> ParserResult {
         std::string srcLC = source;
-        std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( char c ) { return static_cast<char>( ::tolower(c) ); } );
+        std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( char c ) { return static_cast<char>( std::tolower(c) ); } );
         if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
             target = true;
         else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")


### PR DESCRIPTION
Some C++ compilers don't export C functions into `::` scope. This makes
`tolower` accessible to those compilers.

Reference: https://en.cppreference.com/w/cpp/header#C_compatibility_headers