### PR TITLE
added cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,39 +1,62 @@
 cmake_minimum_required(VERSION 3.8.2)
 project(Clara)
 
-set(SOURCE_FILES src/main.cpp src/ClaraTests.cpp include/clara.hpp)
-include_directories( include third_party )
-add_executable(ClaraTests ${SOURCE_FILES})
+add_library(clara INTERFACE)
 
-if(USE_CPP14)
+target_include_directories(
+  clara
+  INTERFACE
+  include/
+)
+
+set(CLARA_MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CLARA_MASTER_PROJECT ON)
+endif()
+
+option(CLARA_BUILD_TESTS "Build tests" ${CLARA_MASTER_PROJECT})
+
+if(CLARA_BUILD_TESTS)
+  add_executable(ClaraTests
+    src/main.cpp
+    src/ClaraTests.cpp
+  )
+
+  target_link_libraries(ClaraTests clara)
+  target_include_directories(ClaraTests
+    PUBLIC
+      third_party)
+
+  if(USE_CPP14)
     set_property(TARGET ClaraTests PROPERTY CXX_STANDARD 14)
     message(STATUS "Enabled C++14")
-elseif(USE_CPP17)
+  elseif(USE_CPP17)
     set_property(TARGET ClaraTests PROPERTY CXX_STANDARD 17)
     message(STATUS "Enabled C++17")
-else(USE_CPP11)
+  else(USE_CPP11)
     set_property(TARGET ClaraTests PROPERTY CXX_STANDARD 11)
     message(STATUS "Enabled C++11")
-endif()
+  endif()
 
-set_property(TARGET ClaraTests PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET ClaraTests PROPERTY CXX_EXTENSIONS OFF)
+  set_property(TARGET ClaraTests PROPERTY CXX_STANDARD_REQUIRED ON)
+  set_property(TARGET ClaraTests PROPERTY CXX_EXTENSIONS OFF)
 
 
-if( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
+  if( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
     target_compile_options( ClaraTests PRIVATE -Wall -Wextra -pedantic -Werror )
-endif()
-if( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
+  endif()
+  if( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 	target_compile_options( ClaraTests PRIVATE /W4 /WX )
-endif()
+  endif()
 
-if (ENABLE_COVERAGE)
+  if (ENABLE_COVERAGE)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
     find_package(codecov)
     add_coverage(ClaraTests)
     list(APPEND LCOV_REMOVE_PATTERNS "/usr/")
     coverage_evaluate()
-endif()
+  endif()
 
-include(CTest)
-add_test(NAME RunTests COMMAND $<TARGET_FILE:ClaraTests>)
+  include(CTest)
+  add_test(NAME RunTests COMMAND $<TARGET_FILE:ClaraTests>)
+endif()


### PR DESCRIPTION
I made two simple changes to make including clara in some cmake projects easier:

1) defined an interface library that other targets could reference. This doesn't go all out and export targets,etc. as I primarily develop on linux and am not sure how to do that in a windows friendly way. But at least it reduces basic cmake (version > 3.11) inclusion  to something like:

```
FetchContent_Declare(
  clara_fc
  GIT_REPOSITORY https://github.com/catchorg/Clara.git
  GIT_TAG v1.1.5
  GIT_SHALLOW TRUE
)

FetchContent_MakeAvailable(clara_fc )

add_executable(main main.cpp)

target_link_libraries(main clara)
```
 
2) added an option to skip building the tests if clara is not the top level project. 